### PR TITLE
Protect organization repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ protector - v0.1.0-SNAPSHOT
     	do not make any changes, just print out what would have been done
   -free
     	remove branch protection
+  -orgs value
+    	organizations name to protect
   -repos value
     	repositories fullname to protect (ex: jcgay/maven-color)
   -token string

--- a/repositories.go
+++ b/repositories.go
@@ -76,3 +76,52 @@ func (sghr *selectedGitHubRepositories) fetch() chan *github.Repository {
 
 	return result
 }
+
+type orgsGitHubRepositories struct {
+	client *github.Client
+	orgs   []string
+}
+
+func (aghr *orgsGitHubRepositories) fetch() chan *github.Repository {
+	result := make(chan *github.Repository, 20)
+	var wg sync.WaitGroup
+	for _, orga := range orgs {
+		wg.Add(1)
+		go func(orga string) {
+			defer wg.Done()
+			aghr.listByOrg(1, orga, result)
+		}(orga)
+	}
+
+	go func() {
+		wg.Wait()
+		close(result)
+	}()
+
+	return result
+}
+
+func (aghr *orgsGitHubRepositories) listByOrg(startPage int, orga string, result chan *github.Repository) {
+	opt := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{
+			Page:    startPage,
+			PerPage: 20,
+		},
+	}
+
+	repos, resp, err := aghr.client.Repositories.ListByOrg(orga, opt)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	for _, repo := range repos {
+		result <- repo
+	}
+
+	if startPage == resp.LastPage || resp.NextPage == 0 {
+		return
+	}
+
+	aghr.listByOrg(resp.NextPage, orga, result)
+}


### PR DESCRIPTION
One can ask for protection by organization name:

    protector -orgas vidal-community -orgas jirac

will protect repositories from the given organizations only.

Fixes #2